### PR TITLE
Refresh device insights layout and move session log to its own tab

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -90,14 +90,13 @@
             <v-tab value="info">Device Info</v-tab>
             <v-tab value="partitions">Partitions</v-tab>
             <v-tab value="flash">Flash Firmware</v-tab>
+            <v-tab value="log">Session Log</v-tab>
           </v-tabs>
 
           <v-window v-model="activeTab">
             <v-window-item value="info">
               <DeviceInfoTab
                 :chip-details="chipDetails"
-                :log-text="logText"
-                @clear-log="clearLog"
               />
             </v-window-item>
 
@@ -122,6 +121,13 @@
                 @firmware-input="handleFirmwareInput"
                 @flash="flashFirmware"
                 @apply-preset="applyOffsetPreset"
+              />
+            </v-window-item>
+
+            <v-window-item value="log">
+              <SessionLogTab
+                :log-text="logText"
+                @clear-log="clearLog"
               />
             </v-window-item>
           </v-window>
@@ -168,6 +174,7 @@ import disconnectedLogo from './assets/disconnected-logo.svg';
 import DeviceInfoTab from './components/DeviceInfoTab.vue';
 import FlashFirmwareTab from './components/FlashFirmwareTab.vue';
 import PartitionsTab from './components/PartitionsTab.vue';
+import SessionLogTab from './components/SessionLogTab.vue';
 
 const SUPPORTED_VENDORS = [
   { usbVendorId: 0x303a },

--- a/src/components/DeviceInfoTab.vue
+++ b/src/components/DeviceInfoTab.vue
@@ -1,50 +1,82 @@
 <template>
   <v-expand-transition>
-    <v-card v-if="chipDetails" class="mb-4" variant="tonal">
-      <v-card-text>
-        <v-row dense>
-          <v-col cols="12" md="6">
-            <div class="text-subtitle-2 text-medium-emphasis">Chip</div>
-            <div class="text-body-1 font-weight-medium">
-              {{ chipDetails.description || chipDetails.name }}
+    <div v-if="chipDetails" class="device-info-wrapper">
+      <v-card class="device-card" elevation="0" variant="flat">
+        <v-card-text class="device-card__body">
+          <div class="device-header">
+            <v-avatar class="device-avatar" size="64">
+              <v-icon size="36">mdi-chip</v-icon>
+            </v-avatar>
+            <div class="device-header__text">
+              <div class="device-title">{{ chipDetails.description || chipDetails.name }}</div>
+              <div class="device-subtitle">{{ chipDetails.name }}</div>
+              <div v-if="chipDetails.mac" class="device-meta">
+                <v-icon size="16" class="me-1">mdi-identifier</v-icon>
+                {{ chipDetails.mac }}
+              </div>
             </div>
-            <div class="text-caption text-medium-emphasis mt-1">
-              {{ chipDetails.name }}
+          </div>
+
+          <v-row class="device-metrics" dense>
+            <v-col cols="12" sm="4">
+              <div class="metric-card">
+                <v-icon class="metric-icon" size="22">mdi-memory</v-icon>
+                <div class="metric-label">Flash Size</div>
+                <div class="metric-value">{{ chipDetails.flashSize || 'Unknown' }}</div>
+                <div v-if="chipDetails.crystal" class="metric-caption">
+                  Crystal {{ chipDetails.crystal }}
+                </div>
+              </div>
+            </v-col>
+            <v-col cols="12" sm="4">
+              <div class="metric-card">
+                <v-icon class="metric-icon" size="22">mdi-tune-variant</v-icon>
+                <div class="metric-label">Feature Set</div>
+                <div class="metric-value">
+                  {{ chipDetails.features?.length ? `${chipDetails.features.length} enabled` : 'Not reported' }}
+                </div>
+                <div class="metric-caption">See the feature list below</div>
+              </div>
+            </v-col>
+            <v-col cols="12" sm="4">
+              <div class="metric-card">
+                <v-icon class="metric-icon" size="22">mdi-information-slab-circle</v-icon>
+                <div class="metric-label">Status</div>
+                <div class="metric-value">Ready</div>
+                <div class="metric-caption">Device details retrieved</div>
+              </div>
+            </v-col>
+          </v-row>
+
+          <div class="features-block">
+            <div class="section-title">
+              <v-icon size="18" class="me-2">mdi-star-circle-outline</v-icon>
+              Features
             </div>
-          </v-col>
-          <v-col cols="12" md="6">
-            <div class="text-subtitle-2 text-medium-emphasis">Flash</div>
-            <div class="text-body-1 font-weight-medium">
-              {{ chipDetails.flashSize || 'Unknown' }}
-            </div>
-            <div class="text-caption text-medium-emphasis mt-1">
-              Crystal: {{ chipDetails.crystal || 'Unknown' }}
-            </div>
-            <div class="text-caption text-medium-emphasis">
-              MAC: {{ chipDetails.mac || 'Unknown' }}
-            </div>
-          </v-col>
-          <v-col cols="12">
-            <div class="text-subtitle-2 text-medium-emphasis mb-2">Features</div>
-            <v-chip-group column>
+            <v-chip-group column class="feature-chip-group">
               <v-chip
                 v-for="feature in chipDetails.features"
                 :key="feature"
-                class="me-2 mb-2"
-                size="small"
-                variant="elevated"
+                class="feature-chip"
                 color="primary"
+                variant="elevated"
+                size="small"
               >
+                <v-icon size="16" start>mdi-check-circle-outline</v-icon>
                 {{ feature }}
               </v-chip>
               <v-chip v-if="!chipDetails.features?.length" size="small" variant="outlined">
                 Not reported
               </v-chip>
             </v-chip-group>
-          </v-col>
-          <v-col v-if="chipDetails.facts?.length" cols="12">
-            <div class="text-subtitle-2 text-medium-emphasis mb-3">Extra Details</div>
-            <v-table density="compact" class="extra-details-table">
+          </div>
+
+          <div v-if="chipDetails.facts?.length" class="extra-details">
+            <div class="section-title mb-3">
+              <v-icon size="18" class="me-2">mdi-list-box-outline</v-icon>
+              Extra Details
+            </div>
+            <v-table density="comfortable" class="extra-details-table">
               <tbody>
                 <tr v-for="fact in chipDetails.facts" :key="fact.label">
                   <td class="extra-details-label">
@@ -57,32 +89,11 @@
                 </tr>
               </tbody>
             </v-table>
-          </v-col>
-        </v-row>
-      </v-card-text>
-    </v-card>
+          </div>
+        </v-card-text>
+      </v-card>
+    </div>
   </v-expand-transition>
-
-  <v-card class="mt-6" variant="tonal">
-    <v-card-title class="text-subtitle-1 font-weight-medium d-flex align-center">
-      <v-icon class="me-2" size="20">mdi-monitor</v-icon>
-      Session Log
-      <v-spacer />
-      <v-btn
-        variant="text"
-        color="primary"
-        size="small"
-        prepend-icon="mdi-trash-can-outline"
-        :disabled="!logText"
-        @click="emit('clear-log')"
-      >
-        Clear
-      </v-btn>
-    </v-card-title>
-    <v-card-text class="log-surface">
-      <pre class="log-output">{{ logText || 'Logs will appear here once actions begin.' }}</pre>
-    </v-card-text>
-  </v-card>
 </template>
 
 <script setup>
@@ -91,37 +102,143 @@ defineProps({
     type: Object,
     default: null,
   },
-  logText: {
-    type: String,
-    default: '',
-  },
 });
-
-const emit = defineEmits(['clear-log']);
 </script>
 
 <style scoped>
-.log-surface {
-  background: rgba(15, 23, 42, 0.72);
-  border-radius: 12px;
-  padding: 12px;
-  max-height: 320px;
-  overflow-y: auto;
+.device-info-wrapper {
+  position: relative;
 }
 
-.log-output {
-  margin: 0;
-  font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.9rem;
-  line-height: 1.45;
-  white-space: pre-wrap;
-  color: rgba(226, 232, 240, 0.9);
+.device-card {
+  border-radius: 20px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--v-theme-primary) 18%, transparent) 0%,
+    color-mix(in srgb, var(--v-theme-surface) 95%, transparent) 100%
+  );
+  border: 1px solid color-mix(in srgb, var(--v-theme-primary) 16%, transparent);
+  overflow: hidden;
+}
+
+.device-card__body {
+  padding: clamp(20px, 4vw, 36px);
+}
+
+.device-header {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 28px;
+}
+
+.device-avatar {
+  background: color-mix(in srgb, var(--v-theme-primary) 28%, transparent);
+  color: color-mix(in srgb, white 92%, transparent);
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
+}
+
+.device-header__text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.device-title {
+  font-size: clamp(1.2rem, 2.8vw, 1.6rem);
+  font-weight: 600;
+  color: color-mix(in srgb, var(--v-theme-on-surface) 96%, transparent);
+}
+
+.device-subtitle {
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--v-theme-on-surface) 70%, transparent);
+}
+
+.device-meta {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--v-theme-primary) 12%, transparent);
+  color: color-mix(in srgb, var(--v-theme-on-surface) 80%, transparent);
+  font-size: 0.8rem;
+  letter-spacing: 0.01em;
+}
+
+.device-metrics {
+  margin-bottom: 24px;
+}
+
+.metric-card {
+  border-radius: 16px;
+  padding: 16px;
+  background: color-mix(in srgb, var(--v-theme-surface) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--v-theme-on-surface) 12%, transparent);
+  min-height: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metric-icon {
+  color: color-mix(in srgb, var(--v-theme-primary) 80%, transparent);
+}
+
+.metric-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--v-theme-on-surface) 60%, transparent);
+}
+
+.metric-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--v-theme-on-surface) 94%, transparent);
+}
+
+.metric-caption {
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--v-theme-on-surface) 55%, transparent);
+}
+
+.features-block {
+  margin-bottom: 28px;
+}
+
+.section-title {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--v-theme-on-surface) 80%, transparent);
+  margin-bottom: 12px;
+}
+
+.feature-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.feature-chip {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--v-theme-primary) 14%, transparent) !important;
+  color: color-mix(in srgb, var(--v-theme-on-primary) 90%, transparent) !important;
+  font-weight: 500;
+}
+
+.extra-details {
+  border-radius: 18px;
+  padding: 20px;
+  background: color-mix(in srgb, var(--v-theme-surface) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--v-theme-on-surface) 10%, transparent);
 }
 
 .extra-details-table {
   border-radius: 12px;
-  background: color-mix(in srgb, var(--v-theme-surface) 80%, transparent);
-  border: 1px solid color-mix(in srgb, var(--v-theme-on-surface) 12%, transparent);
   overflow: hidden;
 }
 
@@ -131,8 +248,8 @@ const emit = defineEmits(['clear-log']);
 }
 
 .extra-details-table :deep(td) {
-  padding: 10px 12px;
-  border-bottom: 1px solid color-mix(in srgb, var(--v-theme-on-surface) 10%, transparent);
+  padding: 12px 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--v-theme-on-surface) 12%, transparent);
 }
 
 .extra-details-table :deep(tbody tr:last-child td) {
@@ -140,7 +257,7 @@ const emit = defineEmits(['clear-log']);
 }
 
 .extra-details-label {
-  color: color-mix(in srgb, var(--v-theme-on-surface) 70%, transparent);
+  color: color-mix(in srgb, var(--v-theme-on-surface) 65%, transparent);
   font-size: 0.85rem;
   letter-spacing: 0.01em;
 }
@@ -149,7 +266,7 @@ const emit = defineEmits(['clear-log']);
   font-weight: 600;
   font-size: 0.9rem;
   text-align: right;
-  color: color-mix(in srgb, var(--v-theme-on-surface) 95%, transparent);
+  color: color-mix(in srgb, var(--v-theme-on-surface) 92%, transparent);
   word-break: break-word;
 }
 

--- a/src/components/SessionLogTab.vue
+++ b/src/components/SessionLogTab.vue
@@ -1,0 +1,74 @@
+<template>
+  <v-card class="session-log-card" variant="tonal">
+    <v-card-title class="session-log-title">
+      <div class="title-text">
+        <v-icon class="me-2" size="20">mdi-monitor</v-icon>
+        Session Log
+      </div>
+      <v-btn
+        variant="text"
+        color="primary"
+        size="small"
+        prepend-icon="mdi-trash-can-outline"
+        :disabled="!logText"
+        @click="emit('clear-log')"
+      >
+        Clear
+      </v-btn>
+    </v-card-title>
+    <v-divider></v-divider>
+    <v-card-text class="log-surface">
+      <pre class="log-output">{{ logText || 'Logs will appear here once actions begin.' }}</pre>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+defineProps({
+  logText: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['clear-log']);
+</script>
+
+<style scoped>
+.session-log-card {
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--v-theme-primary) 18%, transparent);
+  background: color-mix(in srgb, var(--v-theme-surface) 92%, transparent);
+}
+
+.session-log-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  gap: 16px;
+}
+
+.title-text {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.log-surface {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 12px;
+  padding: 14px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.log-output {
+  margin: 0;
+  font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  color: rgba(226, 232, 240, 0.9);
+}
+</style>


### PR DESCRIPTION
## Summary
- restyle the device information view with highlighted metrics, feature chips, and extra detail styling
- move the session log into a dedicated tab for easier access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6901648be79c832d850708ca5f312f9c