### PR TITLE
feat(serial-monitor): re-enter bootloader/stub on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.1
 - Fixed LittleFS now use client getUsage for uploads
+- Serial Monitor: stopping the monitor now automatically returns to maintenance mode (ROM bootloader + stub); use Disconnect to fully close the port.
 - Refactor components to typescript
 - Move SPIFFS utilities from src/utils to src/lib
 - Build: Upgrade `@electron/fuses` to v2.0.0 (requires Node.js >= 22.12.0) and update Forge fuses integration for ESM compatibility

--- a/src/components/SerialMonitorTab.vue
+++ b/src/components/SerialMonitorTab.vue
@@ -93,7 +93,7 @@
         class="monitor-card__info"
         icon="mdi-information-outline"
       >
-        Starting the serial monitor closes the bootloader connection, resets the board into normal firmware mode, and releases the USB port so the browser stops access once you exit. Reconnect with the main <strong>Connect</strong> button before running maintenance (flash, partition tools, etc.).
+        Starting the serial monitor resets the board into normal firmware mode so you can view UART output. Stopping the serial monitor automatically re-enters bootloader (stub) mode for maintenance (flash, partition tools, etc.).
       </v-alert>
       <v-divider />
       <v-card-text ref="terminalEl" class="monitor-terminal">

--- a/src/i18n/translations.js
+++ b/src/i18n/translations.js
@@ -343,6 +343,8 @@ export const translations = {
   'Both NL & CR': '换行+回车',
   'Console run at 115200 bps automatically for reliable output. Flashing uses the baud rate selected in the toolbar.':
     '串口终端自动以 115200 bps 运行以确保可靠输出。烧录使用工具栏中选择的波特率。',
+  'Starting the serial monitor resets the board into normal firmware mode so you can view UART output. Stopping the serial monitor automatically re-enters bootloader (stub) mode for maintenance (flash, partition tools, etc.).':
+    '启动串口监视器会将开发板复位到正常固件模式以查看 UART 输出。停止串口监视器会自动重新进入 Bootloader（stub）维护模式（刷写、分区工具等）。',
   'Starting the serial monitor closes the bootloader connection, resets the board into normal firmware mode, and releases the USB port so the browser stops access once you exit. Reconnect with the main':
     '启动串口终端将关闭 Bootloader 连接，将开发板重置为正常固件模式，并释放 USB 端口，退出后浏览器将停止访问。请使用主',
   'button before running maintenance (flash, partition tools, etc.).':

--- a/src/services/esptoolClient.ts
+++ b/src/services/esptoolClient.ts
@@ -130,9 +130,12 @@ export class CompatibleTransport {
     }
   }
 
-  async *rawRead() {
+  async *rawRead(signal?: AbortSignal) {
     // Stream raw bytes from the loader's shared input buffer without fighting the bootloader reader lock.
     while (true) {
+      if (signal?.aborted) {
+        break;
+      }
       if (!this.loader) {
         break;
       }
@@ -142,6 +145,9 @@ export class CompatibleTransport {
       }
       const buffer = getInputBuffer(this.loader);
       if (buffer && buffer.length > 0) {
+        if (signal?.aborted) {
+          break;
+        }
         const chunk = new Uint8Array(buffer.splice(0));
         if (chunk.length > 0) {
           yield chunk;


### PR DESCRIPTION
- Serial Monitor: stopping the monitor now automatically returns to maintenance mode (ROM bootloader + stub); use Disconnect to fully close the port.
