### PR TITLE
Automatically set the default language based on the browser's language

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -26,6 +26,9 @@ function getBrowserLocale(): SupportedLocale {
 
   const locales = navigator.languages?.length ? navigator.languages : [navigator.language];
   for (const locale of locales) {
+    if (typeof locale !== 'string' || !locale) {
+      continue;
+    }
     const lang = locale.substring(0, 2).toLowerCase();
     if (supportedLocales.includes(lang as SupportedLocale)) {
       return lang as SupportedLocale;


### PR DESCRIPTION
## Summary
What does this PR change?
Automatically detect the browser language: On the first visit, it automatically matches the supported language (en, fr, zh) based on the browser settings (navigator.languages).

## Type
- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Translation (i18n)

## Checklist
- [x] `npm run build` passes
- [ ] Screenshots included (UI changes)
- [ ] No unrelated formatting changes
