### PR TITLE
Support custom partition table offset (fixes #134)

### DIFF
--- a/src/components/PartitionsTab.vue
+++ b/src/components/PartitionsTab.vue
@@ -1,4 +1,28 @@
 <template>
+  <div class="partition-offset-row">
+    <v-text-field
+      :model-value="partitionTableOffset"
+      :label="t('partitions.tableOffset')"
+      :hint="t('partitions.tableOffsetHint')"
+      persistent-hint
+      placeholder="0x8000"
+      density="comfortable"
+      variant="outlined"
+      class="partition-offset-input"
+      :disabled="busy"
+      @update:model-value="value => emit('update:partitionTableOffset', value)"
+    />
+    <v-btn
+      color="primary"
+      variant="outlined"
+      density="comfortable"
+      :disabled="!connected || busy"
+      @click="emit('refreshPartitions')"
+    >
+      <v-icon start>mdi-refresh</v-icon>
+      {{ t('partitions.refreshButton') }}
+    </v-btn>
+  </div>
   <div v-if="!partitionSegments.length" class="partitions-empty">
     <v-card :class="[
       'partitions-empty__card',
@@ -148,6 +172,8 @@ const props = withDefaults(
     unusedSummary?: UnusedFlashSummary | null;
     flashSizeLabel?: string | null;
     connected?: boolean;
+    partitionTableOffset?: string;
+    busy?: boolean;
   }>(),
   {
     partitionSegments: () => [],
@@ -155,8 +181,15 @@ const props = withDefaults(
     unusedSummary: null,
     flashSizeLabel: '',
     connected: false,
+    partitionTableOffset: '0x8000',
+    busy: false,
   },
 );
+
+const emit = defineEmits<{
+  (e: 'update:partitionTableOffset', value: string): void;
+  (e: 'refreshPartitions'): void;
+}>();
 
 const { partitionSegments, formattedPartitions, unusedSummary, flashSizeLabel, connected } = toRefs(props);
 const { t } = useI18n();
@@ -225,6 +258,18 @@ function logPartitionCsv(rows: FormattedPartitionRow[]) {
 </script>
 
 <style scoped>
+.partition-offset-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding-top: 12px;
+  margin-bottom: 16px;
+}
+
+.partition-offset-input {
+  max-width: 320px;
+}
+
 .partition-view {
   display: flex;
   flex-direction: column;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -390,6 +390,9 @@
       size: 'Size',
     },
     unnamed: 'Unnamed',
+    tableOffset: 'Partition Table Offset',
+    tableOffsetHint: 'Flash address of the partition table (default 0x8000). Auto-detected on connect; override for secure boot or custom bootloaders.',
+    refreshButton: 'Refresh',
   },
   filesystem: {
     partitionTitle: '{fs} Partition',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -390,6 +390,9 @@
       size: 'Taille',
     },
     unnamed: 'Sans nom',
+    tableOffset: 'Adresse de la table de partitions',
+    tableOffsetHint: 'Adresse Flash de la table de partitions (défaut : 0x8000). Détectée automatiquement à la connexion ; modifiez pour le démarrage sécurisé ou les chargeurs personnalisés.',
+    refreshButton: 'Rafraîchir',
   },
   filesystem: {
     partitionTitle: 'Partition « {fs} »',

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -388,6 +388,9 @@
       size: '大小',
     },
     unnamed: '未命名',
+    tableOffset: '分区表偏移地址',
+    tableOffsetHint: '分区表的闪存地址（默认 0x8000）。连接时自动检测；如使用安全启动或自定义引导程序，可手动修改。',
+    refreshButton: '刷新',
   },
   filesystem: {
     partitionTitle: '{fs} 分区',

--- a/src/utils/partitions.ts
+++ b/src/utils/partitions.ts
@@ -192,12 +192,43 @@ export async function detectFilesystemType(
   }
 }
 
+const PARTITION_MAGIC = 0x50aa;
+const DEFAULT_PARTITION_TABLE_OFFSET = 0x8000;
+const PARTITION_TABLE_PROBE_OFFSETS = [
+  0x8000, 0x9000, 0xa000, 0xc000, 0xd000, 0xe000, 0x10000,
+];
+
+export async function probePartitionTableOffset(
+  loader: { readFlash: (offset: number, length: number) => Promise<Uint8Array> },
+  log?: LogFn,
+): Promise<number> {
+  for (const candidate of PARTITION_TABLE_PROBE_OFFSETS) {
+    try {
+      const data = await loader.readFlash(candidate, 2);
+      const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+      if (view.getUint16(0, true) === PARTITION_MAGIC) {
+        if (candidate !== DEFAULT_PARTITION_TABLE_OFFSET) {
+          logInfo(log, `Partition table detected at non-standard offset 0x${candidate.toString(16)}.`);
+        }
+        return candidate;
+      }
+    } catch {
+      // probe failed for this offset, try next
+    }
+  }
+  logWarn(log, `No partition table magic found at any probed offset; falling back to default 0x${DEFAULT_PARTITION_TABLE_OFFSET.toString(16)}.`);
+  return DEFAULT_PARTITION_TABLE_OFFSET;
+}
+
 export async function readPartitionTable(
   loader: { readFlash: (offset: number, length: number) => Promise<Uint8Array> },
-  offset = 0x8000,
+  offset?: number,
   length = 0x400,
   log?: LogFn,
 ) {
+  if (offset == null) {
+    offset = await probePartitionTableOffset(loader, log);
+  }
   try {
     const data = await loader.readFlash(offset, length);
     const view = new DataView(data.buffer, data.byteOffset, data.byteLength);


### PR DESCRIPTION
Auto-detect the partition table offset by probing common 0x1000-aligned addresses for the 0x50AA magic bytes, falling back to the standard 0x8000 when no match is found. Expose the detected value in a new Partition Table Offset field on the Partitions tab so users with secure boot or oversized bootloaders can override it manually and refresh.

## Summary

- Auto-detects partition table offset by probing for 0x50AA magic at common addresses (0x8000-0x10000)
- Adds a "Partition Table Offset" field + Refresh button on the Partitions tab for manual override
- Updates the partition map visualization to reflect the detected offset
- i18n strings added for EN, FR, ZH

## Type
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Translation (i18n)

## Checklist
- [x] `npm run build` passes
- [x] Screenshots included (UI changes)
- [x] No unrelated formatting changes

<img width="3306" height="1540" alt="image" src="https://github.com/user-attachments/assets/63693cc7-3924-4b15-9f57-5c7eaac71612" />
